### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ convention, and directory lookup methods (see
 [workflow_calcium_imaging/paths.py](workflow_calcium_imaging/paths.py)).
 3. Ingestion of segmentation and deconvolution results.
 
-+ See the [Element Calcium Imaging documentation](https://elements.datajoint.org/description/calcium_imaging/) for the background information and development timeline.
+See the [Element Calcium Imaging documentation](https://elements.datajoint.org/description/calcium_imaging/) for the background information and development timeline.
 
-+ For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
+For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
 
 ## Workflow architecture
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ convention, and directory lookup methods (see
 [workflow_calcium_imaging/paths.py](workflow_calcium_imaging/paths.py)).
 3. Ingestion of segmentation and deconvolution results.
 
-For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
++ See the [Element Calcium Imaging documentation](https://elements.datajoint.org/description/calcium_imaging/) for the background information and development timeline.
+
++ For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
 
 ## Workflow architecture
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ convention, and directory lookup methods (see
 [workflow_calcium_imaging/paths.py](workflow_calcium_imaging/paths.py)).
 3. Ingestion of segmentation and deconvolution results.
 
-For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported in part by the National Institutes of Health.
+For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported by the National Institutes of Health.
 
 ## Workflow architecture
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ convention, and directory lookup methods (see
 [workflow_calcium_imaging/paths.py](workflow_calcium_imaging/paths.py)).
 3. Ingestion of segmentation and deconvolution results.
 
-See the [DataJoint Elements documentation](https://elements.datajoint.org) for 
-descriptions of the other `elements` and `workflows` developed as part of this National 
-Institutes of Health (NIH)-funded initiative.
+For more information on the DataJoint Elements project, please visit https://elements.datajoint.org.  This work is supported in part by the National Institutes of Health.
 
 ## Workflow architecture
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ workflow ([03-process.ipynb](notebooks/03-process.ipynb)) and explore the data
 + DataJoint for Python or MATLAB
     + Yatsenko D, Reimer J, Ecker AS, Walker EY, Sinz F, Berens P, Hoenselaar A, Cotton RJ, Siapas AS, Tolias AS. DataJoint: managing big scientific data using MATLAB or Python. bioRxiv. 2015 Jan 1:031658. doi: https://doi.org/10.1101/031658
 
-    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for < Python or MATLAB > (version < enter version number >)
+    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for `<Select Python or MATLAB>` (version `<Enter version number>`)
 
 + DataJoint Elements
     + Yatsenko D, Nguyen T, Shen S, Gunalan K, Turner CA, Guzman R, Sasaki M, Sitonic D, Reimer J, Walker EY, Tolias AS. DataJoint Elements: Data Workflows for Neurophysiology. bioRxiv. 2021 Jan 1. doi: https://doi.org/10.1101/2021.03.30.437358
 
-    + DataJoint Elements ([RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894)) - Element Calcium Imaging (version < enter version number >)
+    + DataJoint Elements ([RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894)) - Element Calcium Imaging (version `<Enter version number>`)

--- a/README.md
+++ b/README.md
@@ -43,3 +43,17 @@ assembled together to form a fully functional workflow.
 [Jupyter notebooks](/notebooks) for an in-depth explanation of how to run the 
 workflow ([03-process.ipynb](notebooks/03-process.ipynb)) and explore the data 
 ([05-explore.ipynb](notebooks/05-explore.ipynb)).
+
+## Citation
+
++ If your work uses DataJoint and DataJoint Elements, please cite the respective Research Resource Identifiers (RRIDs) and manuscripts.
+
++ DataJoint for Python or MATLAB
+    + Yatsenko D, Reimer J, Ecker AS, Walker EY, Sinz F, Berens P, Hoenselaar A, Cotton RJ, Siapas AS, Tolias AS. DataJoint: managing big scientific data using MATLAB or Python. bioRxiv. 2015 Jan 1:031658. doi: https://doi.org/10.1101/031658
+
+    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for <Python or MATLAB> (version < enter version number >)
+
++ DataJoint Elements
+    + Yatsenko D, Nguyen T, Shen S, Gunalan K, Turner CA, Guzman R, Sasaki M, Sitonic D, Reimer J, Walker EY, Tolias AS. DataJoint Elements: Data Workflows for Neurophysiology. bioRxiv. 2021 Jan 1. doi: https://doi.org/10.1101/2021.03.30.437358
+
+    + DataJoint Elements ([RRID:SCR_021894](https://scicrunch.org/resolver/SCR_021894)) - Element Calcium Imaging (version < enter version number >)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ convention, and directory lookup methods (see
 [workflow_calcium_imaging/paths.py](workflow_calcium_imaging/paths.py)).
 3. Ingestion of segmentation and deconvolution results.
 
+See the [DataJoint Elements documentation](https://elements.datajoint.org) for 
+descriptions of the other `elements` and `workflows` developed as part of this National 
+Institutes of Health (NIH)-funded initiative.
+
 ## Workflow architecture
 
 The calcium imaging workflow presented here uses components from four DataJoint 
@@ -33,9 +37,8 @@ assembled together to form a fully functional workflow.
 
 ## Installation instructions
 
-+ The installation instructions can be found at 
-[datajoint-elements/install.md](
-     https://github.com/datajoint/datajoint-elements/blob/main/gh-pages/docs/usage/install.md).
++ The installation instructions can be found at the
+[DataJoint Elements documentation](https://elements.datajoint.org/usage/install/).
 
 ## Interacting with the DataJoint workflow
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ workflow ([03-process.ipynb](notebooks/03-process.ipynb)) and explore the data
 + DataJoint for Python or MATLAB
     + Yatsenko D, Reimer J, Ecker AS, Walker EY, Sinz F, Berens P, Hoenselaar A, Cotton RJ, Siapas AS, Tolias AS. DataJoint: managing big scientific data using MATLAB or Python. bioRxiv. 2015 Jan 1:031658. doi: https://doi.org/10.1101/031658
 
-    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for <Python or MATLAB> (version < enter version number >)
+    + DataJoint ([RRID:SCR_014543](https://scicrunch.org/resolver/SCR_014543)) - DataJoint for < Python or MATLAB > (version < enter version number >)
 
 + DataJoint Elements
     + Yatsenko D, Nguyen T, Shen S, Gunalan K, Turner CA, Guzman R, Sasaki M, Sitonic D, Reimer J, Walker EY, Tolias AS. DataJoint Elements: Data Workflows for Neurophysiology. bioRxiv. 2021 Jan 1. doi: https://doi.org/10.1101/2021.03.30.437358


### PR DESCRIPTION
- Add citation section
- Update links to point to elements.datajoint.org instead of the datajoint-elements GitHub repository.