### PR TITLE
Update changelog. Retroactively order version history.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
 ## 0.1.1 - 2022-09-18
+
 + Add - Code of conduct
 + Add - CICD workflows
 + Add - sbxreader requirement
@@ -23,11 +24,18 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Update - Requirements
 + Add - Adopt black formatting into code base
 
-## 0.1.0a2 - 2022-01-24
+## 0.0.0a2 - 2022-01-24
 
 + Update - Change version to reflect release phase
++ Comment - Phase previously designated 0.1.0a2 -> 0.0.0a2
 
-## 0.1.1 - 2021-03-26
+## 0.0.0 - 2021-03-26
 
 + Add - Version
 + Add - Containerization for pytests
++ Comment - Phase previously designated 0.1.0 -> 0.0.0
+
+[0.1.1]: https://github.com/datajoint/workflow-calcium-imaging/compare/0.1.0...0.1.1
+[0.1.0]: https://github.com/datajoint/workflow-calcium-imaging/compare/0.0.0a2...0.1.0
+[0.0.0a2]: https://github.com/datajoint/workflow-calcium-imaging/compare/0.0.0...0.0.0a2
+[0.0.0]: https://github.com/datajoint/workflow-calcium-imaging/releases/tag/0.0.0


### PR DESCRIPTION
I've added tags on previous commits to reflect the history described here. Once merged, I'll add the tag for the new release 0.1.1