### PR TITLE
Update dependencies to reduce Docker image size for GitHub Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,6 @@ RUN \
     apt update && \
     apt-get install bash-completion graphviz default-mysql-client s3fs procps -y && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir flake8 black pre-commit && \
     # workflow dependencies
     apt-get install gcc ffmpeg libsm6 libxext6 -y && \
     # Commented out CaImAn installation due to Docker image size limits on Codespace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
-## [0.3.0] - 2023-08-03
+## [0.3.1] - 2023-03-09
 
-+ Add - Demo capabilities using GitHub CodeSpaces
++ Update - Simplify dependencies to reduce Docker image size for GitHub Codespaces
+
+## [0.3.0] - 2023-03-08
+
++ Add - Demo capabilities using GitHub Codespaces
 
 ## [0.2.0] - 2022-10-14
 
@@ -50,6 +54,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - Containerization for pytests
 + Comment - Phase previously designated 0.1.0 -> 0.0.0
 
+[0.3.1]: https://github.com/datajoint/workflow-calcium-imaging/releases/tag/0.3.1
 [0.3.0]: https://github.com/datajoint/workflow-calcium-imaging/releases/tag/0.3.0
 [0.2.0]: https://github.com/datajoint/workflow-calcium-imaging/releases/tag/0.2.0
 [0.1.4]: https://github.com/datajoint/workflow-calcium-imaging/releases/tag/0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ element-interface>=0.5.0
 element-lab>=0.1.1
 element-session>=0.1.2
 ipykernel>=6.0.1
-jupytext>=1.13.7
 nd2
 sbxreader @ git+https://github.com/datajoint/sbxreader
 scanreader @ git+https://github.com/atlab/scanreader.git

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
-djarchive-client @ git+https://github.com/datajoint/djarchive-client.git
 pytest
 pytest-cov
 shutils

--- a/workflow_calcium_imaging/version.py
+++ b/workflow_calcium_imaging/version.py
@@ -3,4 +3,4 @@ Package metadata
 Update the Docker image tag in `docker-compose-test.yaml` and
 `docker-compose-dev.yaml` to match
 """
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
- [x] Local Docker image build is currently 6.09 GB.
- [x] GitHub Codespace builds and the demo notebooks run correctly.
- After this pull request is merged, I will tag and release this version.